### PR TITLE
Fix Dockerfile to copy drizzle

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -29,6 +29,7 @@ COPY --from=builder /app/package.json .
 COPY --from=builder /app/bun.lock ./bun.lock
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/drizzle ./drizzle
 
 # Ya no copiamos /app/db porque no existe. Si luego deseas semillar,
 # lo haces con `bun` desde un `docker exec`.


### PR DESCRIPTION
## Summary
- copy drizzle folder from builder stage in `Dockerfile.backend`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68596f6f3e34833398cc999c4a7b7319